### PR TITLE
Nested properties

### DIFF
--- a/examples/other_examples/table_example.clj
+++ b/examples/other_examples/table_example.clj
@@ -1,0 +1,71 @@
+(ns other-examples.table-example
+  (:require [fn-fx.fx-dom :as dom]
+            [fn-fx.controls :as ui]
+            [fn-fx.diff :refer [component defui render should-update?]])
+  (:import (javafx.scene.layout Priority)))
+
+
+
+;; We use a multimethod for our event handling, dispatching by the event type.
+(defmulti handle-event (fn [state event]
+                         (:event event)))
+
+
+
+(defmethod handle-event :default [state event]
+  (println "Unknown event type " event))
+
+
+
+
+
+(defn cell-value-factory [f]
+  (reify javafx.util.Callback
+    (call [this entity]
+      (javafx.beans.property.ReadOnlyObjectWrapper. (f (.getValue entity))))))
+
+
+
+(defui MyTable
+       (render [this _]
+               (ui/table-view
+                 :items [{:name "foo" :age 10}
+                         {:name "bar" :age 56}]
+                 :columns [(ui/table-column
+                             :text "Name"
+                             :cell-value-factory (cell-value-factory #(:name %)))
+                           (ui/table-column
+                             :text "Age"
+                             :cell-value-factory (cell-value-factory #(:age %)))])))
+
+
+(defui MainWindow
+       (render [this {:keys [current-value] :as state}]
+               (my-table state)))
+
+
+(defui MainStage
+       (render [this args]
+               (ui/stage
+                 :title "Table Test"
+                 :shown true
+                 :scene (ui/scene
+                          :root (main-window args)))))
+
+
+(defn -main []
+  (let [state (atom {})
+        handler-fn (fn [event]
+                     (try
+                       (swap! state handle-event event)
+                       (catch Exception e (.printStackTrace e))))
+        ui-state (atom (dom/app (main-stage @state) handler-fn))]
+
+    (add-watch state :ui (fn [k r os ns]
+                           (swap! ui-state
+                                  (fn [old-ui]
+                                    (dom/update-app old-ui (main-stage ns))))))))
+
+
+
+

--- a/examples/other_examples/tabpane.clj
+++ b/examples/other_examples/tabpane.clj
@@ -1,0 +1,55 @@
+(ns other-examples.tabpane
+  (:require [fn-fx.fx-dom :as dom]
+            [fn-fx.controls :as ui]
+            [fn-fx.diff :refer [component defui render should-update?]]))
+
+
+(defn handle-event [{:keys [selection-count] :as state} event]
+  (let [tab-text (-> event :fn-fx/includes :my-tabpane :selection-model.selected-item.text)]
+    (println "Tab selected: " tab-text "Selection count:" selection-count)
+    (assoc state :selection-count (inc selection-count))))
+
+
+(defui MainWindow
+       (render [this {:keys [current-value] :as state}]
+               (ui/tab-pane
+                 :id :my-tabpane
+
+                 ;; In JavaFX TabPane listeners are added to the underlying SelectionModel, not to the TabPane instance directly.
+                 ;; fn-fx uses the dot notation to access to the SelectionModel instance
+                 ;; :listen/selection-model.selected-item is equivalent to
+                 ;; tabPane.getSelectionModel().selectedItemProperty().addListener(...)
+                 :listen/selection-model.selected-item {:event         :tab-selected
+
+                                                        ;; we can use the dot notation also for data delivered to the event handler
+                                                        :fn-fx/include {:my-tabpane [:selection-model.selected-item.text]}}
+                 :tabs [(ui/tab :text "Tab 1"
+                                :content (ui/pane :min-width 640 :min-height 480))
+                        (ui/tab :text "Tab 2"
+                                :content (ui/pane :min-width 640 :min-height 480))
+                        (ui/tab :text "Tab 3"
+                                :content (ui/pane :min-width 640 :min-height 480))])))
+
+
+(defui MainStage
+       (render [this args]
+               (ui/stage
+                 :title "Tabpane Test"
+                 :shown true
+                 :scene (ui/scene
+                          :root (main-window args)))))
+
+(defn -main []
+  (let [state (atom {:selection-count 0})
+        handler-fn (fn [event]
+                     (try
+                       (swap! state handle-event event)
+                       (catch Exception e (.printStackTrace e))))
+        ui-state (atom (dom/app (main-stage @state) handler-fn))]
+
+    (add-watch state :ui (fn [k r os ns]
+                           (swap! ui-state
+                                  (fn [old-ui]
+                                    (dom/update-app old-ui (main-stage ns))))))))
+
+

--- a/examples/other_examples/treeview.clj
+++ b/examples/other_examples/treeview.clj
@@ -1,0 +1,100 @@
+(ns other-examples.treeview
+  (:require [fn-fx.fx-dom :as dom]
+            [fn-fx.controls :as ui]
+            [fn-fx.diff :refer [component defui render should-update?]])
+  (:import (javafx.scene.layout Priority)))
+
+
+
+;; We use a multimethod for our event handling, dispatching by the event type.
+(defmulti handle-event (fn [state event]
+                         (:event event)))
+
+
+(defmethod handle-event :node-selected [state {:keys [fn-fx/includes]}]
+  (let [val (get-in includes [:my-tree :selection-model.selected-item.value])]
+
+    (println val "selected")
+
+    ; the return value is the changed state, but only because we wrote -main like this
+    (assoc state :selected-value val)))
+
+
+(defmethod handle-event :default [state event]
+  (println "Unknown event type " event))
+
+
+;; The data for our tree
+(def tree-data ["Animals"
+                ["Vertebrates" ["Fish"] ["Amphibians"] ["Reptiles"] ["Birds"] ["Mammals"]]
+                ["Invertebrates" ["Insects"] ["Worms"] ["Snails"] ["Crabs & Lobsters"]]])
+
+
+
+
+(defn- build-tree [node]
+  (let [val (first node)
+        children (rest node)]
+
+    (if (empty? children)
+
+      (ui/tree-item :value val)
+
+      (ui/tree-item :value val
+                    :children (doall (map build-tree children))))))
+
+
+(defui TreeView
+       (render [this {:keys [current-value] :as state}]
+               (do
+                 (ui/v-box
+                   :children [(ui/tree-view
+                                :id :my-tree
+                                :root (build-tree tree-data)
+                                :v-box/vgrow Priority/ALWAYS
+
+                                ;; In JavaFX TreeView listeners are added to the underlying SelectionModel, not to the TreeView instance directly.
+                                ;; fn-fx uses the dot notation to access to the SelectionModel instance
+                                ;; :listen/selection-model.selected-item is equivalent to
+                                ;; treeView.getSelectionModel().selectedItemProperty().addListener(...)
+                                :listen/selection-model.selected-item {:event         :node-selected
+
+                                                                       ;; here we want to receive the value of treeView.getSelectionModel().getSelectedItem().getValue()
+                                                                       ;; in the event handler
+                                                                       :fn-fx/include {:my-tree [:selection-model.selected-item.value]}}
+                                )]))))
+
+
+
+(defui MainWindow
+       (render [this {:keys [current-value] :as state}]
+               (ui/split-pane
+                 :divider-positions (double-array [0.2])
+                 :items [(tree-view state)])))
+
+
+(defui MainStage
+       (render [this args]
+               (ui/stage
+                 :title "TreeView Test"
+                 :shown true
+                 :scene (ui/scene
+                          :root (main-window args)))))
+
+
+(defn -main []
+  (let [state (atom {})
+        handler-fn (fn [event]
+                     (try
+                       (swap! state handle-event event)
+                       (catch Exception e (.printStackTrace e))))
+        ui-state (atom (dom/app (main-stage @state) handler-fn))]
+
+    (add-watch state :ui (fn [k r os ns]
+                             (swap! ui-state
+                                  (fn [old-ui]
+                                    (dom/update-app old-ui (main-stage ns))))))))
+
+
+
+

--- a/src/fn_fx/diff.clj
+++ b/src/fn_fx/diff.clj
@@ -100,7 +100,7 @@
     nil
     spec-b))
 
-(defn- diff
+(defn diff
   [dom a b]
   (let [refresh-node (fn [node compo-a compo-b]
                        (set-once! compo-b :dom-node node)

--- a/src/fn_fx/diff.clj
+++ b/src/fn_fx/diff.clj
@@ -47,6 +47,11 @@
       (do (set-once! to :render-result (:render-result from))
           false))))
 
+;; this is a quite hacky implementation of the binding mechanism
+;; the problem is that the binding may refer to controls which do not exist yet
+;; so we do all bindings at the end of the diff rendering
+;; this atom is used to accumulate the binding actions in one rendering cycle
+;; a better implementation is for sure possible
 (def bind-actions (atom nil))
 
 (defn- bind-property! [this node property value]

--- a/src/fn_fx/diff.clj
+++ b/src/fn_fx/diff.clj
@@ -47,8 +47,13 @@
       (do (set-once! to :render-result (:render-result from))
           false))))
 
+(def bind-actions (atom nil))
 
-(defn diff-child-list [dom parent-node k a-list b-list]
+(defn- bind-property! [this node property value]
+       (swap! bind-actions conj #(set-property! this node property value)))
+
+
+(defn- diff-child-list [dom parent-node k a-list b-list]
   (dotimes [idx (max (count a-list) (count b-list))]
     (let [a (nth a-list idx nil)
           b (nth b-list idx nil)]
@@ -60,32 +65,37 @@
           Updated (replace-indexed-child! dom parent-node k idx node)
           Noop nil)))))
 
-(defn diff-component [dom dom-node spec-a spec-b]
+(defn- diff-component [dom dom-node spec-a spec-b]
   (reduce-kv
     (fn [_ k va]
       (let [vb (get spec-b k)]
-        (if (sequential? vb)
+           ;;TODO find a better way to detect when a property is supposed to contain children
+        (if (and (sequential? vb) (not= (namespace k) "bind"))
           (diff-child-list dom dom-node k va vb)
           (let [result (diff dom va vb)]
             (if (or (instance? Created result)
                     (instance? Updated result))
-              (set-property! dom dom-node k (:node result)))))))
+              (if (= (namespace k) "bind")
+                (bind-property! dom dom-node k (:node result))
+                (set-property! dom dom-node k (:node result))))))))
     nil
     spec-a)
 
   (reduce-kv
     (fn [_ k vb]
       (when-not (get spec-a k)
-        (if (sequential? vb)
+        (if (and (sequential? vb) (not= (namespace k) "bind"))
           (diff-child-list dom dom-node k nil vb)
           (let [result (diff dom nil vb)]
             (if (or (instance? Created result)
                     (instance? Updated result))
-              (set-property! dom dom-node k (:node result)))))))
+              (if (= (namespace k) "bind")
+                (bind-property! dom dom-node k (:node result))
+                (set-property! dom dom-node k (:node result))))))))
     nil
     spec-b))
 
-(defn diff
+(defn- diff
   [dom a b]
   (let [refresh-node (fn [node compo-a compo-b]
                        (set-once! compo-b :dom-node node)
@@ -126,6 +136,15 @@
       [:comp :nil] (->Deleted (:dom-node a))
 
       [:val :nil] (->Deleted a))))
+
+
+
+(defn render-diff [dom a b]
+      (let [result (diff dom a b)]
+           (swap! bind-actions #(doseq [action %]
+                                       (action)))
+           result))
+
 
 
 (defn component

--- a/src/fn_fx/fx_dom.clj
+++ b/src/fn_fx/fx_dom.clj
@@ -1,6 +1,6 @@
 (ns fn-fx.fx-dom
   (:require [fn-fx.render-core :as render-core]
-            [fn-fx.diff :refer [IDom diff component]]
+            [fn-fx.diff :refer [IDom render-diff component]]
             [fn-fx.util :refer [run-and-wait run-later]])
   (:import (java.util List)))
 
@@ -56,10 +56,10 @@
    (app init-state default-handler-fn))
   ([init-state default-handler-fn]
    (let [dom  (->FXDom default-handler-fn)
-         root (:node (diff dom nil init-state))]
+         root (:node (render-diff dom nil init-state))]
 
      (->App init-state dom root default-handler-fn))))
 
 (defn update-app [{:keys [prev-state dom root handler-fn]} new-state]
-  (let [new-node (:node (diff dom prev-state new-state))]
+  (let [new-node (:node (render-diff dom prev-state new-state))]
     (->App new-state dom new-node handler-fn)))

--- a/src/fn_fx/render_core.clj
+++ b/src/fn_fx/render_core.clj
@@ -11,7 +11,8 @@
            (javafx.beans.value ObservableValue)
            (java.util WeakHashMap)
            (javafx.beans.value ChangeListener)
-           (javafx.stage Window)))
+           (javafx.stage Window)
+           (javafx.beans.property Property)))
 
 (set! *warn-on-reflection* true)
 


### PR DESCRIPTION
I think we can merge nested_properties. Since development is going slow anyway it probably makes little sense to wait any longer. The implementation is a little bit rough around the edges, I'll continue to work on it, but for now I think it's good enough.

Basically this is an enhancement to the API to add support for nested properties and binding of properties. 
With nested properties we can listen to properties which are not directly on the class itself. 
For example to listen for item selection in a `TreeView`, one needs to listen on the `selectedItem` property of the `selectionModel` property, of the `TreeView`. I chose the dot-notation for this, for `TreeView` it looks like this:
```
:listen/selection-model.selected-item
```
Binding of two properties looks like this:
```
:bind/property-name [:target-id :target-property]
```

Nested properties in binding does not work yet (or maybe it does, I haven't tested it), and there's an optimisation needed as well.