### PR TITLE
Add missing convert value

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -29,7 +29,10 @@
                                          :dependencies [[com.github.javaparser/javaparser-core "3.10.0"]]
                                          :plugins      [[lein-release  "1.1.3"]
                                                         [lein-licenses "0.2.2"]
-                                                        [lein-codox    "0.10.5"]]}
+                                                        [lein-codox    "0.10.5"]
+                                                        [cider/cider-nrepl "0.22.0-beta8"]
+                                                        [refactor-nrepl "2.5.0-SNAPSHOT"]
+                                                        [com.billpiel/sayid "0.0.17"]]}
                         :1.8            {:dependencies [[org.clojure/clojure "1.8.0"]]}
                         :1.9            {:dependencies [[org.clojure/clojure "1.9.0"]]}
                         :1.10           {:dependencies [[org.clojure/clojure "1.10.0"]]}

--- a/project.clj
+++ b/project.clj
@@ -29,10 +29,7 @@
                                          :dependencies [[com.github.javaparser/javaparser-core "3.10.0"]]
                                          :plugins      [[lein-release  "1.1.3"]
                                                         [lein-licenses "0.2.2"]
-                                                        [lein-codox    "0.10.5"]
-                                                        [cider/cider-nrepl "0.22.0-beta8"]
-                                                        [refactor-nrepl "2.5.0-SNAPSHOT"]
-                                                        [com.billpiel/sayid "0.0.17"]]}
+                                                        [lein-codox    "0.10.5"]]}
                         :1.8            {:dependencies [[org.clojure/clojure "1.8.0"]]}
                         :1.9            {:dependencies [[org.clojure/clojure "1.9.0"]]}
                         :1.10           {:dependencies [[org.clojure/clojure "1.10.0"]]}

--- a/src/fn_fx/render_core.clj
+++ b/src/fn_fx/render_core.clj
@@ -417,6 +417,10 @@
   [v _]
   (int v))
 
+(defmethod convert-value [Long Integer/TYPE]
+  [v _]
+  (int v))
+
 (defmethod convert-value [Double Double/TYPE]
   [v _]
   (double v))


### PR DESCRIPTION
I found this bug when trying to use (ui/color 100 100 100). Missing convert-value multimethod was triggering an assert error.