### PR TITLE
Choose best value type inplementation

### DIFF
--- a/src/fn_fx/render_core.clj
+++ b/src/fn_fx/render_core.clj
@@ -169,7 +169,7 @@
 
 (defn get-value-ctors [^Class klass]
   (let [ctors (for [{:keys [is-ctor? ^Executable method prop-names-kw prop-types]} (ru/get-value-ctors klass)]
-                [(hash-map (interleave prop-names-kw prop-types))
+                [[prop-names-kw prop-types]
                  (if is-ctor?
                    (fn [args]
                      (let [^objects casted (into-array Object (map convert-value


### PR DESCRIPTION
This fixes #87 (it was choosing the wrong function. The process for choosing the appropriate constructor / builder function would just choose the first one it found that matched the the set of property keywords. ui/color and presumably others have more than one such function. This PR will i the best constructor available by using a score multimethod that give preference to the constructor / builder that best matches the given args. Right now that is just giving preference to matching clojure Longs with other integer types and Doubles with other float types. This can easily be extended by adding more 'score' multimethods as the need arises.