### PR TITLE
Needed to assign int to Integers and vice vesa

### DIFF
--- a/src/fn_fx/render_core.clj
+++ b/src/fn_fx/render_core.clj
@@ -417,6 +417,14 @@
   [v _]
   (int v))
 
+(defmethod convert-value [Long Integer/TYPE]
+  [v _]
+  (int v))
+
+(defmethod convert-value [Integer Integer/TYPE]
+  [v _]
+  (int v))
+
 (defmethod convert-value [Double Double/TYPE]
   [v _]
   (double v))


### PR DESCRIPTION
This is only to avoid triggering the assert where .isAssignableFrom checks
the classes but this only checks classes and does not take into account boxing.